### PR TITLE
reduce dependent libraries Docker image size

### DIFF
--- a/packages/server/sifrr-server/package.json
+++ b/packages/server/sifrr-server/package.json
@@ -29,10 +29,11 @@
   "dependencies": {
     "busboy": "^0.3.0",
     "chokidar": "^3.0.1",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.1"
+  },
+  "peerDependencies": {
     "uWebSockets.js": "uNetworking/uWebSockets.js#v15.11.0"
   },
-  "peerDependencies": {},
   "devDependencies": {
     "@sifrr/dev": "^0.0.13",
     "cache-manager": "^2.9.1",


### PR DESCRIPTION
[This](https://github.com/dalisoft/nanoexpress#credits) uses this library and it's very great that you're build this. Thank you for awesome work.

Also, my [uWebSockets.js dev-env template](https://github.com/dalisoft/uwebsockets-dev-env) uses this library.

But you can some patch for me (and for future of both my and your library)?

This one-line (oh, diff makes it 3-line) patch reduces ~10Mb Dockerfile which great reduction.